### PR TITLE
Fix NoMethodError in Link.parse_query in Ruby< 2.1

### DIFF
--- a/lib/deeplink/link.rb
+++ b/lib/deeplink/link.rb
@@ -113,7 +113,19 @@ module Deeplink
     def parse_query(query_str)
       return unless query_str
 
-      query_str.scan(/([^&=]+)=([^&#{}]*)/).to_h
+     param_name_value_pairs = query_str.scan(/([^&=]+)=([^&#{}]*)/)
+     array_to_h(param_name_value_pairs)
+    end
+
+    #~~~~~~~~~~~~~~
+    private 
+    
+    def array_to_h(array)
+      if array.respond_to?(:to_h)
+        array.to_h
+      else
+        Hash[*array.flatten]
+      end
     end
   end
 end


### PR DESCRIPTION
Hi @rikas, in case you might be interested here is a fix for Ruby 2.0, 
where I get a `NoMethodError` because `Array.to_h` does not exist in this version.

If the code does not comply with what you expect, please let me know in order to adjust it.

And by the way thank you for the gem it is really useful.
- @ebouchut
